### PR TITLE
Switch to v4, connection examples for the metadata v14, wasmonly

### DIFF
--- a/docs/development/develop/smart-contracts/wasm-smart-contracts/tutorials/wasm-setup/upgrade-to-erup-5.md
+++ b/docs/development/develop/smart-contracts/wasm-smart-contracts/tutorials/wasm-setup/upgrade-to-erup-5.md
@@ -11,7 +11,7 @@ Release v4.0.0 is the latest release from Edgeware, this release upgrades Edgewa
 ##### Build from source:
 
 ```bash
-$ git clone https://github.com/edgeware-network/edgeware-node & cd edgeware-node/ & git checkout "v4.0.0" & cargo build --release  
+$ git clone https://github.com/edgeware-network/edgeware-node && cd edgeware-node/ && git checkout "v4.0.0" && cargo build --release  
 ```
 
 

--- a/docs/development/develop/smart-contracts/wasm-smart-contracts/tutorials/wasm-setup/upgrade-to-erup-5.md
+++ b/docs/development/develop/smart-contracts/wasm-smart-contracts/tutorials/wasm-setup/upgrade-to-erup-5.md
@@ -1,12 +1,8 @@
-# Upgrade your Edgeware Node to Erup-5  
+# Upgrade your Edgeware Node to v4.0.0     
 
 
 
-Erup-5 is the latest release from Edgeware, allowing your node client to be able to 
-
-We want to provide a fast setup experience for you. If you have Docker, you can launch an Edgeware development node in a few seconds:
-
-**Note** if you are running a validator using the older edgeware 
+Release v4.0.0 is the latest release from Edgeware, this release upgrades Edgeware's mainnet from [v3.2.0 Tokyo spec_version 46](https://github.com/edgeware-network/edgeware-node/releases/tag/v3.2.0).    
 
 
 ### Step 1: Get the new binary 
@@ -15,7 +11,7 @@ We want to provide a fast setup experience for you. If you have Docker, you can 
 ##### Build from source:
 
 ```bash
-$ git clone https://github.com/edgeware-network/edgeware-node & cd edgeware-node/ & git checkout erup-5-latest & cargo build --release  
+$ git clone https://github.com/edgeware-network/edgeware-node & cd edgeware-node/ & git checkout "v4.0.0" & cargo build --release  
 ```
 
 
@@ -35,5 +31,84 @@ Copy the binary to your validator node and restart your validator with the new b
 
 
 
-Read more about ERUP-5 on the release page:  
-[https://github.com/edgeware-network/edgeware-node/releases/tag/erup-5](https://github.com/edgeware-network/edgeware-node/releases/tag/erup-5)
+## Connect to Edgeware's mainnet with polkadot.js after upgrade     
+Thanks to Parity's [scale codec](https://github.com/paritytech/parity-scale-codec) the chain is able to upgrade from metadata v12 to v14. This enables developers to connect to Edgeware's mainnet without having to use [Edgeware's custom node types](https://classic.yarnpkg.com/en/package/@edgeware/node-types).   
+
+### Before upgrade  
+
+Add `@edgeware/node-types` and `@polkadot/api` to package.json:
+
+```json
+"@edgeware/node-types": "^3.6.2-wako",
+"@polkadot/api": "^9.4.1",
+```
+
+Connect to the chain:
+
+```ts
+import { ApiPromise, WsProvider } from "@polkadot/api";
+import { spec } from '@edgeware/node-types';
+
+const wsProvider = new WsProvider("ws://node:wsport"); // connect to our node using ws
+const api = await ApiPromise.create(
+    {
+      provider: wsProvider,
+      ...spec  //Load EDG Custom spec
+    });
+
+```
+
+
+### After upgrade 
+
+We can now say goodbye to Edgeware's custom node types and we can use metadata v14 and the generic scale codec types.   
+
+Remove `@edgeware/node-types` and `import { spec } from '@edgeware/node-types'` from your code and connect to the chain without node-types spec:  
+
+
+```ts
+async function connect_without_custom_types() {
+  const provider = new WsProvider("ws://node:wsport");
+  const api = await ApiPromise.create({ // create our api instance without adding the spec
+    provider,
+  });
+  return api;
+}
+
+```
+
+#### Use wasm-only interfaces   
+Certain extrinsics requires us to connect with a wasm-only interface. 
+If you see the error:
+```
+Error: The WASM interface has not been initialized. Ensure that you wait for the initialization Promise with waitReady() from @polkadot/wasm-crypto (or cryptoWaitReady() from @polkadot/util-crypto) before attempting to use WASM-only interfaces.
+``` 
+
+
+Execute  `cryptoWaitReady()` before creating the api instance:   
+
+```ts
+import { cryptoWaitReady } from "@polkadot/util-crypto";
+
+
+await cryptoWaitReady();  
+const wsProvider = new WsProvider("ws://node:wsport");
+const api = await ApiPromise.create({
+  provider: wsProvider
+});
+
+```
+
+
+
+Read more about release v4.0.0 here:  
+[https://github.com/edgeware-network/edgeware-node/releases/tag/v4.0.0](https://github.com/edgeware-network/edgeware-node/releases/tag/v4.0.0)
+
+
+Code samples taken from:   
+[https://github.com/flipchan/edgeware-node/blob/erup-5-latest/ts-tests/new_tests/Readme.md](https://github.com/flipchan/edgeware-node/blob/erup-5-latest/ts-tests/new_tests/Readme.md)
+
+
+Polkadot.js WASM interface:  
+[https://polkadot.js.org/docs/util-crypto/FAQ/](https://polkadot.js.org/docs/util-crypto/FAQ/)
+

--- a/sidebars.js
+++ b/sidebars.js
@@ -381,7 +381,7 @@ module.exports = {
 
             {
               type: 'link',
-              label: 'Upgrade your node to ERUP-5', // The link label
+              label: 'Upgrade your node to v4.0.0', // The link label
               href: '/development/develop/smart-contracts/wasm-smart-contracts/tutorials/wasm-setup/upgrade-to-erup-5', // local URL
             },
 


### PR DESCRIPTION
*  Switch erup-5 to v4    
*  Typescript polkadot.js before and after upgrade connection code examples    
*  document wasm-only interface connection   